### PR TITLE
fix for the cURL-not-always-available issue in #27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "homepage": "http://github.com/sqmk/phue",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "5.4.*"
+        "php": "5.4.*",
+        "ext-curl": "*"
     },
     "require-dev": {
         "phpunit/PHPUnit": "3.7.*"

--- a/library/Phue/Transport/Http.php
+++ b/library/Phue/Transport/Http.php
@@ -56,6 +56,10 @@ class Http implements TransportInterface
      */
     public function __construct(Client $client)
     {
+        if (!extension_loaded('curl')) {
+            throw new \BadFunctionCallException('The cURL extension is required.');
+        }
+
         $this->client = $client;
     }
 


### PR DESCRIPTION
Added the curl php extension to the composer.json require block.

Added an extension_loaded() check in the constructor of the HTTP
transport class, with an exception throw when it is not loaded.
