### PR TITLE
Check if color mode property exists before returning it

### DIFF
--- a/library/Phue/Light.php
+++ b/library/Phue/Light.php
@@ -437,7 +437,7 @@ class Light
      */
     public function getColorMode()
     {
-        return $this->attributes->state->colormode;
+        return property_exists($this->attributes->state, 'colormode') ? $this->attributes->state->colormode : null;
     }
 
     /**

--- a/library/Phue/Light.php
+++ b/library/Phue/Light.php
@@ -437,7 +437,9 @@ class Light
      */
     public function getColorMode()
     {
-        return property_exists($this->attributes->state, 'colormode') ? $this->attributes->state->colormode : null;
+        return property_exists($this->attributes->state, 'colormode')
+            ? $this->attributes->state->colormode
+            : null;
     }
 
     /**

--- a/tests/Phue/Test/LightTest.php
+++ b/tests/Phue/Test/LightTest.php
@@ -373,12 +373,23 @@ class LightTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->attributes->state->colormode, 
             $this->light->getColorMode());
+
+        // Let's assume our light does not support color modes.
+        // That way, the colormode property in state is missing.
+        $reflection = new \ReflectionClass($this->light);
+        $property = $reflection->getProperty('attributes');
+        $property->setAccessible(true);
+
+        $property->setValue($this->light, (object) array('state' => (object) array()));
+
+        $this->assertNull($this->light->getColorMode());
     }
 
+
     /**
-     * Test: Get color mode
+     * Test: Is reachable
      *
-     * @covers \Phue\Group::getColorMode
+     * @covers \Phue\Light::isReachable
      */
     public function testIsReachable()
     {


### PR DESCRIPTION
Some lights don't support color, hence, we expect `getColorMode()` to return null. This already happens, but throws a `undefined property` notice.

This PR addresses this issue by first checking if the property exists.