### PR TITLE
Extend Group and Light from LightInterface

### DIFF
--- a/library/Phue/Group.php
+++ b/library/Phue/Group.php
@@ -16,7 +16,7 @@ use Phue\Command\SetGroupState;
 /**
  * Group object
  */
-class Group
+class Group implements LightInterface
 {
 
     /**
@@ -99,9 +99,9 @@ class Group
         $x = new SetGroupAttributes($this);
         $y = $x->name((string) $name);
         $this->client->sendCommand($y);
-        
+
         $this->attributes->name = (string) $name;
-        
+
         return $this;
     }
 
@@ -126,17 +126,17 @@ class Group
     public function setLights(array $lights)
     {
         $lightIds = array();
-        
+
         foreach ($lights as $light) {
             $lightIds[] = (string) $light;
         }
-        
+
         $x = new SetGroupAttributes($this);
         $y = $x->lights($lightIds);
         $this->client->sendCommand($y);
-        
+
         $this->attributes->lights = $lightIds;
-        
+
         return $this;
     }
 
@@ -163,9 +163,9 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->on((bool) $flag);
         $this->client->sendCommand($y);
-        
+
         $this->attributes->action->on = (bool) $flag;
-        
+
         return $this;
     }
 
@@ -194,8 +194,8 @@ class Group
         $this->attributes->action->alert = $mode;
         return $this;
     }
-    
-    
+
+
     /**
      * Get brightness
      *
@@ -219,9 +219,9 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->brightness((int) $level);
         $this->client->sendCommand($y);
-        
+
         $this->attributes->action->bri = (int) $level;
-        
+
         return $this;
     }
 
@@ -248,11 +248,11 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->hue((int) $value);
         $this->client->sendCommand($y);
-        
+
         // Change both hue and color mode state
         $this->attributes->action->hue = (int) $value;
         $this->attributes->action->colormode = 'hs';
-        
+
         return $this;
     }
 
@@ -279,11 +279,11 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->saturation((int) $value);
         $this->client->sendCommand($y);
-        
+
         // Change both saturation and color mode state
         $this->attributes->action->sat = (int) $value;
         $this->attributes->action->colormode = 'hs';
-        
+
         return $this;
     }
 
@@ -319,14 +319,14 @@ class Group
         $_x = new SetGroupState($this);
         $_y = $_x->xy((float) $x, (float) $y);
         $this->client->sendCommand($_y);
-        
+
         // Change both internal xy and colormode state
         $this->attributes->action->xy = array(
             $x,
             $y
         );
         $this->attributes->action->colormode = 'xy';
-        
+
         return $this;
     }
 
@@ -353,11 +353,11 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->colorTemp((int) $value);
         $this->client->sendCommand($y);
-        
+
         // Change both internal color temp and colormode state
         $this->attributes->action->ct = (int) $value;
         $this->attributes->action->colormode = 'ct';
-        
+
         return $this;
     }
 
@@ -384,9 +384,9 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->effect($mode);
         $this->client->sendCommand($y);
-        
+
         $this->attributes->action->effect = $mode;
-        
+
         return $this;
     }
 
@@ -413,7 +413,7 @@ class Group
         $x = new SetGroupState($this);
         $y = $x->scene((string) $scene);
         $this->client->sendCommand($y);
-        
+
         return $this;
     }
 

--- a/library/Phue/Light.php
+++ b/library/Phue/Light.php
@@ -16,7 +16,7 @@ use Phue\LightModel\LightModelFactory;
 /**
  * Light object
  */
-class Light
+class Light implements LightInterface
 {
     /**
      * Id

--- a/library/Phue/LightInterface.php
+++ b/library/Phue/LightInterface.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Phue: Philips Hue PHP Client
+ *
+ * @author    Karim Geiger <geiger@karim.email>
+ * @copyright Copyright (c) 2016 Michael K. Squires
+ * @license   http://github.com/sqmk/Phue/wiki/License
+ */
+namespace Phue;
+
+use Phue\Command\SetLightState;
+
+/**
+ * Interface for lights and groups.
+ */
+interface LightInterface
+{
+    /**
+     * Get light or group Id
+     *
+     * @return int Light/Group id
+     */
+    public function getId();
+
+    /**
+     * Get assigned name of light or group
+     *
+     * @return string Name of light/group
+     */
+    public function getName();
+
+    /**
+     * Set name of light/group
+     *
+     * @param string $name
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setName($name);
+
+    /**
+     * Get type
+     *
+     * @return string Type
+     */
+    public function getType();
+
+    /**
+     * Is the light or group on?
+     *
+     * @return bool True if on, false if not
+     */
+    public function isOn();
+
+    /**
+     * Set light or group on/off
+     *
+     * @param bool $flag
+     *            True for on, false for off
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setOn($flag = true);
+
+    /**
+     * Get alert
+     *
+     * @return string Alert mode
+     */
+    public function getAlert();
+
+    /**
+     * Set light or group alert
+     *
+     * @param string $mode
+     *            Alert mode
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setAlert($mode = SetLightState::ALERT_LONG_SELECT);
+
+    /**
+     * Get effect mode
+     *
+     * @return string effect mode
+     */
+    public function getEffect();
+
+    /**
+     * Set effect
+     *
+     * @param string $mode
+     *            Effect mode
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setEffect($mode = SetLightState::EFFECT_NONE);
+
+    /**
+     * Get brightness
+     *
+     * @return int Brightness level
+     */
+    public function getBrightness();
+
+    /**
+     * Set brightness
+     *
+     * @param int $level
+     *            Brightness level
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setBrightness($level = SetLightState::BRIGHTNESS_MAX);
+
+    /**
+     * Get hue
+     *
+     * @return int Hue value
+     */
+    public function getHue();
+
+    /**
+     * Set hue
+     *
+     * @param int $value
+     *            Hue value
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setHue($value);
+
+    /**
+     * Get saturation
+     *
+     * @return int Saturation value
+     */
+    public function getSaturation();
+
+    /**
+     * Set saturation
+     *
+     * @param int $value
+     *            Saturation value
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setSaturation($value);
+
+    /**
+     * Get XY
+     *
+     * @return array X, Y key/value
+     */
+    public function getXY();
+
+    /**
+     * Set XY
+     *
+     * @param float $x
+     *            X value
+     * @param float $y
+     *            Y value
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setXY($x, $y);
+
+    /**
+     * Get Color temperature
+     *
+     * @return int Color temperature value
+     */
+    public function getColorTemp();
+
+    /**
+     * Set Color temperature
+     *
+     * @param int $value Color temperature value
+     *
+     * @return \Phue\LightInterface
+     */
+    public function setColorTemp($value);
+
+    /**
+     * Get color mode of light
+     *
+     * @return string Color mode
+     */
+    public function getColorMode();
+}


### PR DESCRIPTION
This helps to ensure all methods exist when mixing groups and lights.

Additionally, this removes spaces at line endings.