### PR TITLE
Add missing setRGB and getRGB functions

### DIFF
--- a/library/Phue/Group.php
+++ b/library/Phue/Group.php
@@ -12,6 +12,7 @@ use Phue\Command\DeleteGroup;
 use Phue\Command\SetLightState;
 use Phue\Command\SetGroupAttributes;
 use Phue\Command\SetGroupState;
+use Phue\Helper\ColorConversion;
 
 /**
  * Group object

--- a/library/Phue/Group.php
+++ b/library/Phue/Group.php
@@ -331,6 +331,47 @@ class Group implements LightInterface
     }
 
     /**
+     * Get calculated RGB
+     *
+     * @return array red, green, blue key/value
+     */
+    public function getRGB()
+    {
+        $xy  = $this->getXY();
+        $bri = $this->getBrightness();
+        $rgb = ColorConversion::convertXYToRGB($xy['x'], $xy['y'], $bri);
+
+        return $rgb;
+    }
+
+    /**
+     * Set XY and brightness calculated from RGB
+     *
+     * @param int $red   Red value
+     * @param int $green Green value
+     * @param int $blue  Blue value
+     *
+     * @return self This object
+     */
+    public function setRGB($red, $green, $blue)
+    {
+        $x = new SetGroupState($this);
+        $y = $x->rgb((int) $red, (int) $green, (int) $blue);
+        $this->client->sendCommand($y);
+
+        // Change internal xy, brightness and colormode state
+        $xy = ColorConversion::convertRGBToXY($red, $green, $blue);
+        $this->attributes->action->xy = array(
+            $xy['x'],
+            $xy['y']
+        );
+        $this->attributes->action->bri = $xy['bri'];
+        $this->attributes->action->colormode = 'xy';
+
+        return $this;
+    }
+
+    /**
      * Get Color temperature
      *
      * @return int Color temperature value

--- a/tests/Phue/Test/GroupTest.php
+++ b/tests/Phue/Test/GroupTest.php
@@ -9,6 +9,7 @@
 namespace Phue\Test;
 
 use Phue\Client;
+use Phue\Helper\ColorConversion;
 use Phue\Group;
 
 /**

--- a/tests/Phue/Test/GroupTest.php
+++ b/tests/Phue/Test/GroupTest.php
@@ -307,7 +307,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
                 'red' => $rgb['red'],
                 'green' => $rgb['green'],
                 'blue' => $rgb['blue']
-            ), $this->light->getRGB());
+            ), $this->group->getRGB());
 
         // Ensure setRGB returns self
         $this->assertEquals($this->group, $this->group->setRGB(50, 50, 50));

--- a/tests/Phue/Test/GroupTest.php
+++ b/tests/Phue/Test/GroupTest.php
@@ -286,6 +286,41 @@ class GroupTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test: Get/Set RGB
+     *
+     * @covers \Phue\Group::getRGB
+     * @covers \Phue\Group::setRGB
+     */
+    public function testGetSetRGB()
+    {
+        $this->stubMockClientSendSetGroupStateCommand();
+
+        // Make sure original rgb is retrievable
+        $rgb = ColorConversion::convertXYToRGB(
+            $this->attributes->action->xy[0],
+            $this->attributes->action->xy[1],
+            $this->attributes->action->bri
+        );
+        $this->assertEquals(
+            array(
+                'red' => $rgb['red'],
+                'green' => $rgb['green'],
+                'blue' => $rgb['blue']
+            ), $this->light->getRGB());
+
+        // Ensure setRGB returns self
+        $this->assertEquals($this->group, $this->group->setRGB(50, 50, 50));
+
+        // Make sure group attributes are updated
+        $this->assertEquals(
+            array(
+                'red' => 50,
+                'green' => 50,
+                'blue' => 50
+            ), $this->group->getRGB());
+    }
+
+    /**
      * Test: Get/Set Color temp
      *
      * @covers \Phue\Group::getColorTemp


### PR DESCRIPTION
In the documentation, it's explained that the `getRGB` and `setRGB` functions are available on both `Light` ang `Group` objects.

Unfortunately it appear that these functions are (currently) only available on the `Light` object.

So here is my little copy/past to add these functions to the `Group` object.