### PR TITLE
Change schedule ids from int to string as ids can overflow

### DIFF
--- a/library/Phue/Command/GetScheduleById.php
+++ b/library/Phue/Command/GetScheduleById.php
@@ -27,12 +27,12 @@ class GetScheduleById implements CommandInterface
     /**
      * Constructs a command
      *
-     * @param int $scheduleId
+     * @param string $scheduleId
      *            Schedule Id
      */
     public function __construct($scheduleId)
     {
-        $this->scheduleId = (int) $scheduleId;
+        $this->scheduleId = (string) $scheduleId;
     }
 
     /**

--- a/library/Phue/Schedule.php
+++ b/library/Phue/Schedule.php
@@ -31,7 +31,7 @@ class Schedule
     /**
      * Id
      *
-     * @var int
+     * @var string
      */
     protected $id;
 
@@ -52,7 +52,7 @@ class Schedule
     /**
      * Construct a Phue Schedule object
      *
-     * @param int $id
+     * @param string $id
      *            Id
      * @param \stdClass $attributes
      *            Schedule attributes
@@ -61,7 +61,7 @@ class Schedule
      */
     public function __construct($id, \stdClass $attributes, Client $client)
     {
-        $this->id = (int) $id;
+        $this->id = (string) $id;
         $this->attributes = $attributes;
         $this->client = $client;
     }
@@ -69,7 +69,7 @@ class Schedule
     /**
      * Get schedule Id
      *
-     * @return int Schedule id
+     * @return string Schedule id
      */
     public function getId()
     {


### PR DESCRIPTION
Type casting the Schedule ID to int creates an integer overflow. This can be tested with the following ID as made by the Hue app: 9218378804149269. This results in the int overflowing to make the ID 2147483647.