### PR TITLE
Support charset definition in Content-Type header

### DIFF
--- a/library/Phue/Transport/Http.php
+++ b/library/Phue/Transport/Http.php
@@ -227,7 +227,7 @@ class Http implements TransportInterface
         $contentType = $this->getAdapter()->getContentType();
         
         // Throw connection exception if status code isn't 200 or wrong content type
-        if ($status != 200 || $contentType != 'application/json') {
+        if ($status != 200 || substr($contentType, 0, strpos($contentType, ';')) != 'application/json') {
             throw new ConnectionException('Connection failure');
         }
         

--- a/library/Phue/Transport/Http.php
+++ b/library/Phue/Transport/Http.php
@@ -227,7 +227,7 @@ class Http implements TransportInterface
         $contentType = $this->getAdapter()->getContentType();
         
         // Throw connection exception if status code isn't 200 or wrong content type
-        if ($status != 200 || substr($contentType, 0, strpos($contentType, ';')) != 'application/json') {
+        if ($status != 200 || explode(';', $contentType)[0] != 'application/json') {
             throw new ConnectionException('Connection failure');
         }
         


### PR DESCRIPTION
The Philips Hue Bridge emulator I'm using right now returns Content-Type: application/json; charset=utf-8" header, which made this library fail. I don't know whether the actual Hue Bridge does, perhaps in newer or future versions. 