### PR TITLE
Fix notice if no mac address returned by the api.

### DIFF
--- a/bin/phue-bridge-finder
+++ b/bin/phue-bridge-finder
@@ -31,6 +31,7 @@ foreach ($bridges as $key => $bridge) {
     echo "\tBridge #", ++$key, "\n";
     echo "\t\tID: ", $bridge->id, "\n";
     echo "\t\tInternal IP Address: ", $bridge->internalipaddress, "\n";
-    echo "\t\tMAC Address: ", $bridge->macaddress, "\n";
+    if(isset($bridge->macaddress))
+        echo "\t\tMAC Address: ", $bridge->macaddress, "\n";
     echo "\n";
 }


### PR DESCRIPTION
My request on https://www.meethue.com/api/nupnp return no mac address, so there is a notice of undefined $macadress in the stdclass.