### PR TITLE
Fix brigthness

### DIFF
--- a/library/Phue/Helper/ColorConversion.php
+++ b/library/Phue/Helper/ColorConversion.php
@@ -56,7 +56,7 @@ class ColorConversion
         return array(
             'x'   => $x,
             'y'   => $y,
-            'bri' => round($xyz['y'] * 255)
+            'bri' => max($red,$green,$blue)
         );
     }
 


### PR DESCRIPTION
The most accurate way to set brigthness for RGB, is to alway take the max R,G,B value (If you try a colorpicker, you set 150, 43,56, and you change only the hue, you alway have 150 on R, G or B, and brigthness will not change.
exemaple : With RGB (0 ,0, 255) you expect a 100% brigth blue so bri = 255
If you take Y you have a wrong very low blue (4,7% brightness).