### PR TITLE
Enable scan for specific lights

### DIFF
--- a/library/Phue/Command/StartLightScan.php
+++ b/library/Phue/Command/StartLightScan.php
@@ -16,6 +16,23 @@ use Phue\Transport\TransportInterface;
  */
 class StartLightScan implements CommandInterface
 {
+    /**
+     * Device Ids
+     *
+     * @var string[]|null
+     */
+    protected $deviceIds;
+
+    /**
+     * Constructs a command
+     *
+     * @param string[]|null $deviceIds
+     *            Array of device ids
+     */
+    public function __construct(array $deviceIds = null)
+    {
+        $this->deviceIds = $deviceIds;
+    }
 
     /**
      * Send command
@@ -27,12 +44,20 @@ class StartLightScan implements CommandInterface
      */
     public function send(Client $client)
     {
+        $body = null;
+
+        if ($this->deviceIds !== null) {
+            $body = new \stdClass();
+            $body->deviceid = $this->deviceIds;
+        }
+
         // Get response
         $response = $client->getTransport()->sendRequest(
             "/api/{$client->getUsername()}/lights",
-            TransportInterface::METHOD_POST
+            TransportInterface::METHOD_POST,
+            $body
         );
-        
+
         return $response;
     }
 }


### PR DESCRIPTION
The Philips Hue API allows you to scan for specific devices (see 1.3.2). I would like to do this with the client aswell.