### PR TITLE
Fix bug where getContentType would return "application/json\r" instead of "application/json"

### DIFF
--- a/library/Phue/Transport/Adapter/Streaming.php
+++ b/library/Phue/Transport/Adapter/Streaming.php
@@ -112,7 +112,7 @@ class Streaming implements AdapterInterface
         $meta_data = stream_get_meta_data($this->fileStream);
         return implode(
             $meta_data['wrapper_data'],
-            "\r\n"
+            "\n"
         );
     }
 


### PR DESCRIPTION
This would prevent the Streaming Transport from working properly because the test `explode(';', $contentType)[0] != 'application/json'` would always return false, and the Http Transport would assume the request failed.