### PR TITLE
Use application/json in request headers

### DIFF
--- a/library/Phue/Transport/Adapter/Curl.php
+++ b/library/Phue/Transport/Adapter/Curl.php
@@ -60,7 +60,8 @@ class Curl implements AdapterInterface
         curl_setopt($this->curl, CURLOPT_HEADER, false);
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
         
-        if (strlen($body)) {
+        if (isset($body) && strlen($body)) {
+            curl_setopt($this->curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Accept: application/json'));
             curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
         }
         


### PR DESCRIPTION
Using Wireshark I realized the curl adapter sends the `Content-Type: application/x-www-form-urlencoded` header by default when sending a body/payload in the HTTP Request.

The Request body is **json**, so it should be marked as such, even if the Hue Bridge is "stupid enough" to accept the invalid combination of header and payload.

Also prevents this Deprecation Warning: 
> Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in 
> …\vendor\sqmk\phue\library\Phue\Transport\Adapter\Curl.php on line 63
